### PR TITLE
Added support to Panic trigger.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,15 @@
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="fullSensor"
             tools:replace="screenOrientation" />
-
+        <activity
+            android:name=".Activities.PanicResponderActivity"
+            android:launchMode="singleInstance"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/PanicResponderActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/PanicResponderActivity.java
@@ -1,0 +1,40 @@
+package org.shadowice.flocke.andotp.Activities;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+
+import org.shadowice.flocke.andotp.Database.Entry;
+import org.shadowice.flocke.andotp.R;
+
+import java.util.ArrayList;
+
+import static org.shadowice.flocke.andotp.Utilities.DatabaseHelper.saveDatabase;
+
+public class PanicResponderActivity extends Activity {
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            // Clean custom configuration.
+            SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
+            sharedPref.edit().clear().commit();
+            PreferenceManager.setDefaultValues(this, R.xml.preferences, true);
+            // Override secrets database
+            saveDatabase(this, new ArrayList<Entry>());
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}


### PR DESCRIPTION
After reading https://github.com/flocke/andOTP/issues/23#issuecomment-321928171
I realized that it would be a nice feature to have.

When the user triggers a Panic action the user preferences and secrets database are wiped.
The user will be able to restore from a secure backup when she's in a safe place.

Let me know if there's something that needs to be changed/added for it to be merged.

Cheers 😄 