### PR TITLE
Remove duplicate credits for german translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ So make sure you have a **current backup** before switching!
 ------ | ----------------- | -----------
 🇵🇱   | Polish (pl-rPL)   | [Daniel Pustuła](https://github.com/9Cube-dpustula)
 :es:   | Spanish (es-rES)  | [Carlos Melero](https://crowdin.com/profile/carmebar)
-:de:   | German (de-rDE)   | [SuperVirus](https://crowdin.com/profile/SuperVirus), [Chris Heitkamp](https://crowdin.com/profile/christophheitkamp)
+:de:   | German (de-rDE)   | [SuperVirus](https://crowdin.com/profile/SuperVirus)
 :fr:   | French (fr-rFR)   | [Johan Fleury](https://github.com/johanfleury)
 🇳🇱   | Dutch (nl-rNL)    | Toon, [rain2reign](https://crowdin.com/profile/rain2reign)
 &nbsp; | Galician (gl-rES) | [Triskel](https://crowdin.com/profile/triskel)


### PR DESCRIPTION
The second account was accidently created by me, using the wrong login provider...
I've already deleted the account.