### PR TITLE
Support exporting as a UriKeyFormat file

### DIFF
--- a/app/src/androidTest/java/org/shadowice/flocke/andotp/ApplicationTest.java
+++ b/app/src/androidTest/java/org/shadowice/flocke/andotp/ApplicationTest.java
@@ -55,6 +55,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import static org.shadowice.flocke.andotp.Utilities.TokenCalculator.DEFAULT_ALGORITHM;
 import static org.shadowice.flocke.andotp.Utilities.TokenCalculator.TOTP_DEFAULT_PERIOD;
 
 public class ApplicationTest extends ApplicationTestCase<Application> {
@@ -147,6 +148,42 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
         assertEquals("ACME Co - ACME Co:john.doe@email.com", entry.getLabel());
 
         assertEquals("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ", new String(new Base32().encode(entry.getSecret())));
+    }
+
+    public void testToURL() throws Exception {
+
+        Entry entry = new Entry(
+                Entry.OTPType.TOTP,
+                "HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ",
+                30,
+                6,
+                "ACME Co:john.doe@email.com",
+                TokenCalculator.HashAlgorithm.SHA1);
+
+        assertEquals("otpauth://totp/ACME%20Co:john.doe@email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30", entry.toUriKey());
+
+        entry = new Entry(
+                Entry.OTPType.TOTP,
+                "HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ",
+                30,
+                6,
+                "ACME Co - john.doe@email.com",
+                TokenCalculator.HashAlgorithm.SHA1);
+
+        assertEquals("otpauth://totp/ACME%20Co:john.doe@email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30", entry.toUriKey());
+
+        entry = new Entry();
+        entry.setDigits(0);
+        entry.setPeriod(0);
+        entry.setLabel("Foobar");
+        entry.setType(Entry.OTPType.TOTP);
+        entry.setSecret("12345678901234567890".getBytes(StandardCharsets.US_ASCII));
+
+        assertEquals("otpauth://totp/Foobar?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ&algorithm=" + DEFAULT_ALGORITHM.toString(), entry.toUriKey());
+
+        String uriFormat = "otpauth://totp/ACME%20Co:john.doe@email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30";
+        entry = new Entry(uriFormat);
+        assertEquals(uriFormat, entry.toUriKey());
     }
 
     public void testSettingsHelper() throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {

--- a/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Activities/SettingsActivity.java
@@ -39,6 +39,7 @@ import org.openintents.openpgp.util.OpenPgpAppPreference;
 import org.openintents.openpgp.util.OpenPgpKeyPreference;
 import org.shadowice.flocke.andotp.Preferences.PasswordHashPreference;
 import org.shadowice.flocke.andotp.R;
+import org.shadowice.flocke.andotp.Utilities.Settings;
 
 public class SettingsActivity extends BaseActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener{
@@ -147,6 +148,11 @@ public class SettingsActivity extends BaseActivity
             super.onCreate(savedInstanceState);
 
             addPreferencesFromResource(R.xml.preferences);
+
+            Settings settings = new Settings(getActivity());
+            if(settings.getSpecialFeatures()) {
+                addPreferencesFromResource(R.xml.preferences_special_features);
+            }
 
             // Authentication
             catSecurity = (PreferenceCategory) findPreference(getString(R.string.settings_key_cat_security));

--- a/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Settings.java
+++ b/app/src/main/java/org/shadowice/flocke/andotp/Utilities/Settings.java
@@ -274,4 +274,8 @@ public class Settings {
     public boolean getOpenPGPVerify() {
         return getBoolean(R.string.settings_key_openpgp_verify, false);
     }
+
+    public boolean getBackupAsUriKeyFormat() {
+        return getBoolean(R.string.settings_key_use_urikeyformat, false);
+    }
 }

--- a/app/src/main/res/layout/content_backup.xml
+++ b/app/src/main/res/layout/content_backup.xml
@@ -38,6 +38,7 @@
                 android:text="@string/backup_title_export_plain" />
 
             <TextView
+                android:id="@+id/text_view_backup_plain_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -60,6 +61,7 @@
                 android:text="@string/backup_title_import_plain" />
 
             <TextView
+                android:id="@+id/text_view_restore_plain_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -100,6 +102,7 @@
                 android:text="@string/backup_title_export_crypt" />
 
             <TextView
+                android:id="@+id/text_view_backup_crypt_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -122,6 +125,7 @@
                 android:text="@string/backup_title_import_crypt" />
 
             <TextView
+                android:id="@+id/text_view_restore_crypt_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -162,6 +166,7 @@
                 android:text="@string/backup_title_export_openpgp" />
 
             <TextView
+                android:id="@+id/text_view_backup_openpgp_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -184,6 +189,7 @@
                 android:text="@string/backup_title_import_openpgp" />
 
             <TextView
+                android:id="@+id/text_view_restore_openpgp_desc"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"

--- a/app/src/main/res/values-es-rES/strings_settings.xml
+++ b/app/src/main/res/values-es-rES/strings_settings.xml
@@ -6,6 +6,7 @@
   <string name="settings_category_title_security">Seguridad</string>
   <string name="settings_category_title_ui">Interfaz de usuario</string>
   <string name="settings_category_title_backup">Copia de seguridad</string>
+  <string name="settings_category_title_secrets">Opciones experimentales</string>
   <!-- Titles -->
   <string name="settings_title_tap_to_reveal">Toca para mostrar</string>
   <string name="settings_title_auth">Autenticación</string>
@@ -21,6 +22,7 @@
   <string name="settings_title_openpgp_keyid">Seleccionar clave OpenPGP</string>
   <string name="settings_title_openpgp_sign">Firmar copias de seguridad cifradas</string>
   <string name="settings_title_openpgp_verify">Comprobar copias de seguridad cifradas</string>
+  <string name="settings_title_use_urikeyformat">Usar formato UriKeyFormat</string>
   <!-- Descriptions -->
   <string name="settings_desc_tap_to_reveal">Esconder códigos OTP por defecto,
         necesitando mostrarlos manualmente</string>
@@ -35,6 +37,8 @@
         tu clave (necesita contraseña)</string>
   <string name="settings_desc_openpgp_verify">Las contraseñas de copias de seguridad cifradas sólo se importan
         si están firmadas con una clave válida</string>
+  <string name="settings_desc_use_urikeyformat">Usar UriKeyFormat para todas las copias de seguridad
+        y restauraciones en lugar de JSON</string>
   <!-- Toasts -->
   <string name="settings_toast_auth_device_pre_lollipop">Esta característica requiere al menos
         Android 5.0 (Lollipop)</string>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -23,6 +23,9 @@
     <string name="settings_key_openpgp_sign" translatable="false">pref_openpgp_sign</string>
     <string name="settings_key_openpgp_verify" translatable="false">pref_openpgp_verify</string>
 
+    <string name="settings_key_cat_special_features" translatable="false">pref_cat_special_features</string>
+    <string name="settings_key_use_urikeyformat" translatable="false">pref_backup_urikeyformat</string>
+
     <string name="settings_key_security_backup_warning" translatable="false">pref_security_backup_warning_shown</string>
     <string name="settings_key_sort_mode" translatable="false">pref_sort_mode</string>
     <string name="settings_key_special_features" translatable="false">pref_special_features</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -49,4 +49,8 @@
     <string name="backup_toast_openpgp_error">OpenPGP Error: %s</string>
     <string name="backup_toast_openpgp_not_verified">No verified signature detected</string>
     <string name="backup_toast_crypt_password_not_set">Password not set, check the Settings</string>
+
+    <!-- File types -->
+    <string name="backup_filetype_json">JSON</string>
+    <string name="backup_filetype_urikeyformat">UriKey</string>
 </resources>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -6,6 +6,7 @@
     <string name="settings_category_title_security">Security</string>
     <string name="settings_category_title_ui">User interface</string>
     <string name="settings_category_title_backup">Backup</string>
+    <string name="settings_category_title_secrets">Secret features</string>
 
     <!-- Titles -->
     <string name="settings_title_tap_to_reveal">Tap to reveal</string>
@@ -24,6 +25,7 @@
     <string name="settings_title_openpgp_keyid">Select OpenPGP key</string>
     <string name="settings_title_openpgp_sign">Sign encrypted backups</string>
     <string name="settings_title_openpgp_verify">Verify encrypted backups</string>
+    <string name="settings_title_use_urikeyformat">Use UriKeyFormat</string>
 
     <!-- Descriptions -->
     <string name="settings_desc_tap_to_reveal">Hide the OTP tokens by default, requiring them to be
@@ -41,6 +43,8 @@
         your key (requires password)</string>
     <string name="settings_desc_openpgp_verify">Encrypted backups are only imported if they are
         signed with a valid key</string>
+
+    <string name="settings_desc_use_urikeyformat">Use UriKeyFormat for all backups and restores rather than JSON</string>
 
     <!-- Toasts -->
     <string name="settings_toast_auth_device_pre_lollipop">This feature requires at least Android 5.0

--- a/app/src/main/res/xml/preferences_special_features.xml
+++ b/app/src/main/res/xml/preferences_special_features.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:key="@string/settings_key_cat_special_features"
+        android:title="@string/settings_category_title_secrets">
+
+        <CheckBoxPreference
+            android:key="@string/settings_key_use_urikeyformat"
+            android:title="@string/settings_title_use_urikeyformat"
+            android:summary="@string/settings_desc_use_urikeyformat"
+            android:defaultValue="false" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>
+


### PR DESCRIPTION
Fixes #62 

This commit adds the option to save backups as UriKeys rather than JSON. The toggle is under a new settings section which visible if a user has enabled special features.